### PR TITLE
Add request headers for data portal calls

### DIFF
--- a/dadosAbertosSetorEletrico/__init__.py
+++ b/dadosAbertosSetorEletrico/__init__.py
@@ -6,6 +6,29 @@ import requests
 
 class dadosAbertosSetorEletrico:
 
+    DEFAULT_HEADERS = {
+        # User-Agent identificando a biblioteca para os portais de dados abertos
+        'User-Agent': 'DadosAbertosSetorEletrico/1.0',
+
+        # Negociação de conteúdo
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+        'Accept-Language': 'pt-BR,pt;q=0.9,en;q=0.8,en-US;q=0.7',
+
+        # Suporte a compressão
+        'Accept-Encoding': 'gzip, deflate, br',
+
+        # Controle de conexão e cache
+        'Connection': 'keep-alive',
+        'Cache-Control': 'max-age=0',
+
+        # Headers adicionais comuns em navegadores
+        'Upgrade-Insecure-Requests': '1',
+        'Sec-Fetch-Dest': 'document',
+        'Sec-Fetch-Mode': 'navigate',
+        'Sec-Fetch-Site': 'none',
+        'Sec-Fetch-User': '?1',
+    }
+
     def __init__(self, instituicao: str):
         """
         Inicializa a classe com a instituição desejada: CCEE, ONS ou ANEEL.
@@ -23,12 +46,14 @@ class dadosAbertosSetorEletrico:
         else:
             raise ValueError("Instituição não encontrada!")  # Gera erro se a instituição for inválida
 
+        self.headers = self.DEFAULT_HEADERS.copy()
+
     def listar_produtos_disponiveis(self):
         """
         Retorna uma lista com todos os produtos disponíveis na API.
         Cada produto representa um conjunto de dados públicos que pode ser consultado.
         """
-        r = requests.get(self.host + self.api + "package_list")
+        r = requests.get(self.host + self.api + "package_list", headers=self.headers)
         return r.json()
 
     def __buscar_resource_ids_por_produto(self, produto: str):
@@ -36,7 +61,7 @@ class dadosAbertosSetorEletrico:
         Retorna os IDs dos arquivos (resources) relacionados a um produto.
         Cada resource_id representa uma tabela acessível via API.
         """
-        r = requests.get(self.host + self.api + f"package_show?id={produto}")
+        r = requests.get(self.host + self.api + f"package_show?id={produto}", headers=self.headers)
         return [item['id'] for item in r.json()['result']['resources'] if 'id' in item]
 
     async def __fetch_offset(self, client, resource_id, offset, limit):
@@ -79,7 +104,7 @@ class dadosAbertosSetorEletrico:
         ids = self.__buscar_resource_ids_por_produto(produto)  # Busca os IDs dos arquivos (resources)
 
         # Cria um cliente HTTP assíncrono
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(headers=self.headers) as client:
             # Cria uma lista de tarefas assíncronas, uma para cada resource_id
             tarefas = [self.__baixar_resource_completo(client, rid) for rid in ids]
             # Executa todas as tarefas ao mesmo tempo

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,4 +14,5 @@ packages = find:
 install_requires =
     requests
     pandas
+    httpx
 python_requires = >=3.8

--- a/tests/test_dadosAbertosSetorEletrico.py
+++ b/tests/test_dadosAbertosSetorEletrico.py
@@ -27,6 +27,9 @@ def test_listar_produtos_disponiveis(mock_get):
     cliente = dadosAbertosSetorEletrico("ccee")
     produtos = cliente.listar_produtos_disponiveis()
     assert produtos["result"] == ["produto1", "produto2"]
+    mock_get.assert_called_once_with(
+        cliente.host + cliente.api + "package_list", headers=cliente.headers
+    )
 
 # -------------------
 # Teste de busca de resource_ids simulando resposta da API
@@ -40,6 +43,10 @@ def test_buscar_resource_ids(mock_get):
     cliente = dadosAbertosSetorEletrico("ccee")
     ids = cliente._dadosAbertosSetorEletrico__buscar_resource_ids_por_produto("algum-produto")
     assert ids == ["abc", "def"]
+    mock_get.assert_called_once_with(
+        cliente.host + cliente.api + "package_show?id=algum-produto",
+        headers=cliente.headers,
+    )
 
 # -------------------
 # Teste assíncrono com multiplos resource_ids e paginação


### PR DESCRIPTION
### Motivation
- Ensure requests to ONS, ANEEL and CCEE identify the client and resemble browser requests to improve compatibility and observability.  
- Use a single shared header set so synchronous `requests.get` and asynchronous `httpx.AsyncClient` behave consistently.  

### Description
- Add a `DEFAULT_HEADERS` dict with `User-Agent`, content negotiation, compression, cache/connection and common browser headers and expose it as `self.headers`.  
- Pass `self.headers` into synchronous calls `requests.get(..., headers=self.headers)` in `listar_produtos_disponiveis` and `__buscar_resource_ids_por_produto`.  
- Configure the async HTTP client with `async with httpx.AsyncClient(headers=self.headers)` for all async downloads.  
- Add `httpx` to `install_requires` in `setup.cfg` and update unit tests to assert that `requests.get` is called with `headers=cliente.headers`.

### Testing
- Ran `python -m compileall dadosAbertosSetorEletrico tests setup.cfg` which succeeded.  
- Ran `pytest -q` which failed during collection with `ModuleNotFoundError: No module named 'httpx'`.  
- Attempt to install dependencies with `python -m pip install httpx pytest-asyncio pandas requests` failed due to a network/proxy `403 Forbidden`, so full test execution could not complete.  
- Updated tests now assert header propagation for `requests.get` (unit test modifications present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6158cb9fa0833382fb03cd12d60753)