### PR TITLE
Add GitHub Actions CI and PyPI publish workflows and add httpx dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    name: Testes (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - name: Checkout do repositório
+        uses: actions/checkout@v4
+
+      - name: Configurar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Instalar dependências
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Rodar testes
+        run: python -m pytest -v
+
+  build:
+    name: Validar pacote Python
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout do repositório
+        uses: actions/checkout@v4
+
+      - name: Configurar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Instalar ferramentas de build
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Gerar distribuições
+        run: python -m build
+
+      - name: Validar metadados do pacote
+        run: python -m twine check dist/*

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,67 @@
+name: Publicar no PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Testes antes da publicação
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout do repositório
+        uses: actions/checkout@v4
+
+      - name: Configurar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Instalar dependências
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Rodar testes
+        run: python -m pytest -v
+
+  publish:
+    # Publica somente quando uma GitHub Release for publicada.
+    # O PyPI precisa estar configurado com Trusted Publishing para este repositório,
+    # workflow e ambiente; nenhuma senha/token é armazenada no GitHub.
+    name: Build e publicação
+    needs: test
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dados-abertos-setor-eletrico
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout do repositório
+        uses: actions/checkout@v4
+
+      - name: Configurar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Instalar ferramentas de build
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Gerar distribuições
+        run: python -m build
+
+      - name: Publicar no PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -118,6 +118,51 @@ tests/test_dadosAbertosSetorEletrico.py::test_baixar_dados_mockado PASSED
 Contribuições são muito bem-vindas!
 Se você quiser sugerir melhorias, corrigir bugs ou adicionar novas funcionalidades, sinta-se à vontade para abrir uma issue ou pull request.
 
+## 🚀 CI/CD e publicação no PyPI
+
+O projeto usa GitHub Actions para automatizar validações e publicação de novas versões.
+
+### Validação contínua
+
+A esteira `CI` é executada em pushes para `main`/`master` e em pull requests. Ela:
+
+- executa a suíte de testes em Python 3.8, 3.9, 3.10, 3.11 e 3.12;
+- gera as distribuições do pacote com `python -m build`;
+- valida os metadados gerados com `twine check`.
+
+### Publicação de uma nova versão
+
+A esteira `Publicar no PyPI` é disparada somente quando uma GitHub Release é publicada. Antes de publicar, ela roda os testes novamente, gera os artefatos `sdist` e `wheel` e usa a action `pypa/gh-action-pypi-publish` para enviar esses arquivos ao PyPI.
+
+### Como a publicação no PyPI funciona
+
+A publicação não usa senha nem token salvo no repositório. Ela usa **PyPI Trusted Publishing**, em que o PyPI confia no GitHub Actions deste repositório por OIDC.
+
+O workflow não precisa saber o login/senha da sua conta PyPI. A ligação acontece em duas partes:
+
+1. **Nome do projeto no PyPI:** vem do metadata do pacote em `setup.cfg`, no campo `name = dados-abertos-setor-eletrico`. É esse nome que define para qual projeto do PyPI os artefatos serão enviados.
+2. **Permissão para publicar:** vem da configuração feita dentro do PyPI, na conta que administra o projeto. No PyPI, você cadastra este repositório GitHub como **Trusted Publisher** do projeto `dados-abertos-setor-eletrico`. Quando a action roda, o PyPI valida via OIDC se a execução veio exatamente do repositório, workflow e environment configurados.
+
+Para isso funcionar, é necessário configurar uma vez no projeto do PyPI `dados-abertos-setor-eletrico` um publicador confiável com estes dados:
+
+- **Owner/organization:** `diegonerii`
+- **Repository name:** `Dados-Abertos-Setor-Eletrico-Brasileiro`
+- **Workflow name:** `publish-pypi.yml`
+- **Environment name:** `pypi`
+
+Depois dessa configuração, o fluxo é:
+
+1. Atualize o campo `version` em `setup.cfg`.
+2. Faça commit e merge das alterações na branch principal.
+3. Crie uma Release no GitHub com uma tag no padrão `vX.Y.Z`, por exemplo `v0.1.5`.
+4. Publique a Release.
+5. O GitHub Actions executa a action `Publicar no PyPI`; se os testes passarem, o pacote é enviado automaticamente para o PyPI.
+
+> Para reduzir risco de publicação acidental, o workflow não possui disparo manual. Se quiser uma aprovação humana antes do envio, configure uma regra de proteção no ambiente `pypi` em **Settings > Environments** no GitHub.
+
+> Se preferir usar token de API em vez de Trusted Publishing, configure um secret `PYPI_API_TOKEN` e adapte o passo `Publicar no PyPI` do workflow para enviar `password: ${{ secrets.PYPI_API_TOKEN }}`.
+
+
 ## Fontes oficiais
 
 - **Portal de Dados Abertos da CCEE** → [Acessar Portal](https://dadosabertos.ccee.org.br/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 pandas
 python-dotenv
+httpx

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,4 +14,5 @@ packages = find:
 install_requires =
     requests
     pandas
+    httpx
 python_requires = >=3.8


### PR DESCRIPTION
### Motivation

- Introduce automated CI to validate the package across multiple Python versions and enable automated PyPI publishing when a GitHub Release is published.
- Ensure the package build and metadata are validated before release.
- Add `httpx` as a runtime dependency required by recent code changes.

### Description

- Added a CI workflow in `/.github/workflows/ci.yml` that runs `pytest` on Python `3.8`–`3.12`, installs dependencies from `requirements.txt`, and builds the package with `python -m build` and validates metadata with `twine check`.
- Added a publish workflow in `/.github/workflows/publish-pypi.yml` that runs tests on `3.12`, builds distributions, and publishes to PyPI via `pypa/gh-action-pypi-publish` when a GitHub Release is published using PyPI Trusted Publishing (OIDC) and the `pypi` environment.
- Updated `README.md` with a new „CI/CD and publication on PyPI" section documenting the workflows, the release flow, and Trusted Publishing setup steps.
- Added `httpx` to `requirements.txt` and to `install_requires` in `setup.cfg` to include the new runtime dependency.

### Testing

- No automated CI runs were executed as part of this PR; the workflows were added and are configured but have not been triggered yet.
- The `CI` workflow is configured to run `python -m pytest -v` across Python versions `3.8`–`3.12` and to run `python -m build` and `python -m twine check dist/*` for package validation.
- The `Publicar no PyPI` workflow is configured to run tests on `3.12`, build distributions with `python -m build`, and publish using `pypa/gh-action-pypi-publish` after a release if tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6161e969bc8333853de70c96f4f13a)