### PR TITLE
Prepare release 0.1.5: normalizar URLs, robustecer HTTP e testes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include README.md
+
+include LICENSE.txt

--- a/README.md
+++ b/README.md
@@ -1,177 +1,131 @@
-# ⚡ Dados Abertos do Setor Elétrico 
-![Avatar Twitter 1](https://github.com/user-attachments/assets/f7e05698-789b-41cc-8965-bb9a2f28b14b)
+# ⚡ Dados Abertos do Setor Elétrico
 
-![ons-logo@2x ac52821bc48c70c7d00b5fd88ad4a3c8f4013a25](https://github.com/user-attachments/assets/0a1f3849-d6f9-4ea6-801b-d03fca56f5f8)
+Biblioteca Python para consultar APIs CKAN de dados abertos do setor elétrico brasileiro nas instituições **CCEE**, **ONS** e **ANEEL**.
 
-![images](https://github.com/user-attachments/assets/93c6ca2f-0df1-4fc3-86b8-057bfc385cd8)
-
-Este projeto oferece uma interface simples em Python para acessar e baixar dados públicos do Setor Elétrico nos 3 principais órgãos: **CCEE (Câmara de Comercialização de Energia Elétrica)**, **ONS (Operador Nacional do Sistema)** e **ANEEL (Agência Nacional de Energia Elétrica)**.
-
-## Introdução
-
-Através da classe `dadosAbertosSetorEletrico`, você pode listar produtos disponíveis e baixar os dados completos de forma paginada e organizada com `pandas`.
-
-### ✅ Funcionalidades
-
-- 🔍 Listagem de produtos disponíveis na API da CCEE  
-- ⬇️ Download completo e incremental dos datasets  
-- 📦 Conversão automática para `pandas.DataFrame`
-
-### ⚙️ Pré-requisitos
-
-Antes de começar, certifique-se de ter os seguintes softwares instalados:
-
-- **Python** 3.8 ou superior → [Download Python](https://www.python.org/downloads/)
-- **pip** (gerenciador de pacotes do Python)
-- **Git** → [Download Git](https://git-scm.com/downloads)
-- **Editor de código** (sugestão: [Visual Studio Code](https://code.visualstudio.com/))
-
-### 📦 Instalação
-
-Clone este repositório e instale as dependências:
+## Instalação
 
 ```bash
-# Clone o repositório
-git clone https://github.com/seu-usuario/seu-repositorio.git
-cd seu-repositorio
-
-# (Opcional) Crie e ative um ambiente virtual
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
-
-# Instale as dependências
-pip install -r requirements.txt
+pip install dados-abertos-setor-eletrico
 ```
 
-## Exemplo de uso
+Para desenvolvimento local:
+
+```bash
+git clone https://github.com/diegonerii/Dados-Abertos-Setor-Eletrico-Brasileiro.git
+cd Dados-Abertos-Setor-Eletrico-Brasileiro
+python -m pip install -e .
+```
+
+## Inicialização
 
 ```python
 from dadosAbertosSetorEletrico import dadosAbertosSetorEletrico
 
-# Inicializa o cliente
 cliente = dadosAbertosSetorEletrico("ccee")
+```
 
-# Lista os produtos disponíveis na API da CCEE
-produtos = cliente.listar_produtos_disponiveis()
-print(produtos)
+Instituições aceitas: `"ccee"`, `"ons"` e `"aneel"`. Os nomes podem ser informados em letras maiúsculas ou misturadas.
 
-# Baixa todos os dados do produto desejado como DataFrame
-df = cliente.baixar_dados_produto_completo("parcela_carga_consumo")
+Por padrão, cada requisição usa `timeout=30.0` e envia um `User-Agent` identificável. Você pode customizar:
+
+```python
+cliente = dadosAbertosSetorEletrico(
+    "aneel",
+    timeout=10,
+    headers={"X-Origem": "minha-aplicacao"},
+)
+```
+
+## Listagem de produtos
+
+`listar_produtos_disponiveis()` preserva a resposta completa do CKAN:
+
+```python
+resposta = cliente.listar_produtos_disponiveis()
+produtos = resposta["result"]
+print(produtos[:5])
+```
+
+A URL gerada para `package_list` segue sempre o formato sem barras duplicadas:
+
+- `https://dadosabertos.ccee.org.br/api/3/action/package_list`
+- `https://dados.ons.org.br/api/3/action/package_list`
+- `https://dadosabertos.aneel.gov.br/api/3/action/package_list`
+
+## Download síncrono
+
+Use em scripts Python comuns, quando não há um event loop ativo:
+
+```python
+df = cliente.baixar_dados_produto_completo("nome-do-produto")
 print(df.head())
 ```
 
-## ✅ Testes Automatizados
+O método retorna sempre um `pandas.DataFrame` quando executado com sucesso. Produtos ou recursos sem registros retornam `pd.DataFrame()` vazio.
 
-Este projeto já vem com uma suíte completa de testes automatizados que garante o funcionamento correto de cada parte do código. Mesmo que você nunca tenha usado testes em Python, aqui está como fazer funcionar.
+## Download assíncrono
 
-### 🧪 O que está sendo testado?
+Use em Jupyter Notebook, Google Colab ou aplicações assíncronas:
 
-- Inicialização correta da classe `dadosAbertosSetorEletrico`
-- Comunicação com a API para listar produtos
-- Extração de IDs de recursos (datasets)
-- Download de dados completos de forma assíncrona
-- Casos de erro simulados e retorno vazio
-
-Os testes estão localizados na pasta:
-
-tests/test_dadosAbertosSetorEletrico.py
-
-Todos os testes estão **comentados passo a passo** para facilitar a leitura até mesmo para iniciantes.
-
-### ⚙️ Como rodar os testes
-
-1. Instale os pacotes de teste (se ainda não tiver feito):
-
-```bash
-pip install pytest pytest-asyncio
+```python
+df = await cliente.baixar_dados_produto_completo_async("nome-do-produto")
 ```
 
-2. Execute os testes na raiz do projeto:
+O método síncrono `baixar_dados_produto_completo()` não retorna mais `asyncio.Task` quando existe um event loop ativo. Nesses ambientes ele levanta `RuntimeError` com orientação para usar `await cliente.baixar_dados_produto_completo_async(...)`, evitando tipos de retorno inconsistentes.
+
+## Tratamento de erros
+
+A biblioteca valida erros HTTP, JSON inválido e respostas CKAN com `success: false`.
+
+```python
+from dadosAbertosSetorEletrico import (
+    DadosAbertosSetorEletricoError,
+    dadosAbertosSetorEletrico,
+)
+
+cliente = dadosAbertosSetorEletrico("ons", timeout=10)
+
+try:
+    resposta = cliente.listar_produtos_disponiveis()
+except DadosAbertosSetorEletricoError as exc:
+    print(f"Falha ao consultar dados abertos: {exc}")
+```
+
+No download assíncrono, quando apenas alguns recursos falham, os recursos válidos são retornados e um `warnings.warn()` informa quais recursos falharam. Se todos os recursos falharem, uma exceção é lançada.
+
+## Testes
+
+Testes unitários usam mocks e não dependem da internet:
 
 ```bash
-pytest -v 
+python -m pip install pytest
+pytest -v
 ```
-- O -v significa “modo verboso” e exibe o nome de cada teste sendo executado.
 
-Se tudo estiver funcionando corretamente, você verá algo assim:
+### Testes de integração opcionais
+
+Os testes reais das APIs são desabilitados por padrão e não baixam bases grandes. Para executar apenas `package_list` real da CCEE, ONS e ANEEL:
 
 ```bash
-tests/test_dadosAbertosSetorEletrico.py::test_init_ccee PASSED
-tests/test_dadosAbertosSetorEletrico.py::test_listar_produtos_disponiveis PASSED
-tests/test_dadosAbertosSetorEletrico.py::test_baixar_dados_mockado PASSED
-...
+RUN_INTEGRATION_TESTS=1 pytest -m integration -v
 ```
 
-- ✅ Dica: Se você estiver usando Jupyter Notebook ou Google Colab, prefira usar o método await cliente.baixar_dados_produto_completo_async(...) para rodar de forma assíncrona.
+## Publicação para mantenedores
 
-## Observações Importantes
+Não inclua credenciais em arquivos do repositório. Antes de publicar uma nova versão:
 
-- Nem todos os datasets possuem dados acessíveis via API (`datastore_search`). Quando não disponíveis, o script mostra a URL para download manual.
+```bash
+rm -rf build dist *.egg-info
+python -m build
+python -m twine check dist/*
+python -m twine upload dist/*
+```
 
-- Alguns datasets podem conter muitos registros — a paginação automática com `limit` e `offset` evita estouro de memória.
-
-- A classe trata de forma unificada três instituições distintas, facilitando reuso do código.
-
-
-## Contribuições
-
-Contribuições são muito bem-vindas!
-Se você quiser sugerir melhorias, corrigir bugs ou adicionar novas funcionalidades, sinta-se à vontade para abrir uma issue ou pull request.
-
-## 🚀 CI/CD e publicação no PyPI
-
-O projeto usa GitHub Actions para automatizar validações e publicação de novas versões.
-
-### Validação contínua
-
-A esteira `CI` é executada em pushes para `main`/`master` e em pull requests. Ela:
-
-- executa a suíte de testes em Python 3.8, 3.9, 3.10, 3.11 e 3.12;
-- gera as distribuições do pacote com `python -m build`;
-- valida os metadados gerados com `twine check`.
-
-### Publicação de uma nova versão
-
-A esteira `Publicar no PyPI` é disparada somente quando uma GitHub Release é publicada. Antes de publicar, ela roda os testes novamente, gera os artefatos `sdist` e `wheel` e usa a action `pypa/gh-action-pypi-publish` para enviar esses arquivos ao PyPI.
-
-### Como a publicação no PyPI funciona
-
-A publicação não usa senha nem token salvo no repositório. Ela usa **PyPI Trusted Publishing**, em que o PyPI confia no GitHub Actions deste repositório por OIDC.
-
-O workflow não precisa saber o login/senha da sua conta PyPI. A ligação acontece em duas partes:
-
-1. **Nome do projeto no PyPI:** vem do metadata do pacote em `setup.cfg`, no campo `name = dados-abertos-setor-eletrico`. É esse nome que define para qual projeto do PyPI os artefatos serão enviados.
-2. **Permissão para publicar:** vem da configuração feita dentro do PyPI, na conta que administra o projeto. No PyPI, você cadastra este repositório GitHub como **Trusted Publisher** do projeto `dados-abertos-setor-eletrico`. Quando a action roda, o PyPI valida via OIDC se a execução veio exatamente do repositório, workflow e environment configurados.
-
-Para isso funcionar, é necessário configurar uma vez no projeto do PyPI `dados-abertos-setor-eletrico` um publicador confiável com estes dados:
-
-- **Owner/organization:** `diegonerii`
-- **Repository name:** `Dados-Abertos-Setor-Eletrico-Brasileiro`
-- **Workflow name:** `publish-pypi.yml`
-- **Environment name:** `pypi`
-
-Depois dessa configuração, o fluxo é:
-
-1. Atualize o campo `version` em `setup.cfg`.
-2. Faça commit e merge das alterações na branch principal.
-3. Crie uma Release no GitHub com uma tag no padrão `vX.Y.Z`, por exemplo `v0.1.5`.
-4. Publique a Release.
-5. O GitHub Actions executa a action `Publicar no PyPI`; se os testes passarem, o pacote é enviado automaticamente para o PyPI.
-
-> Para reduzir risco de publicação acidental, o workflow não possui disparo manual. Se quiser uma aprovação humana antes do envio, configure uma regra de proteção no ambiente `pypi` em **Settings > Environments** no GitHub.
-
-> Se preferir usar token de API em vez de Trusted Publishing, configure um secret `PYPI_API_TOKEN` e adapte o passo `Publicar no PyPI` do workflow para enviar `password: ${{ secrets.PYPI_API_TOKEN }}`.
-
+A versão atual preparada para publicação é `0.1.5`.
 
 ## Fontes oficiais
 
-- **Portal de Dados Abertos da CCEE** → [Acessar Portal](https://dadosabertos.ccee.org.br/)
-
-- **Portal de Dados Abertos da ONS** → [Acessar Portal](https://dados.ons.org.br/)
-
-- **Portal de Dados Abertos da ANEEL** → [Acessar Portal](https://dadosabertos.aneel.gov.br/)
-
-- **CKAN API Reference (oficial)** → [Acessar Documentação (Inglês)](https://docs.ckan.org/en/2.11/)
-
-
-
+- [Portal de Dados Abertos da CCEE](https://dadosabertos.ccee.org.br/)
+- [Portal de Dados Abertos do ONS](https://dados.ons.org.br/)
+- [Portal de Dados Abertos da ANEEL](https://dadosabertos.aneel.gov.br/)
+- [CKAN API Reference](https://docs.ckan.org/en/2.11/)

--- a/dadosAbertosSetorEletrico/__init__.py
+++ b/dadosAbertosSetorEletrico/__init__.py
@@ -1,105 +1,237 @@
-import asyncio      
-import httpx        
-import pandas as pd 
-import requests     
+"""Cliente para APIs CKAN de dados abertos do setor elétrico brasileiro."""
+
+import asyncio
+import warnings
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+import pandas as pd
+import requests
+
+__version__ = "0.1.5"
+
+
+class DadosAbertosSetorEletricoError(Exception):
+    """Erro base da biblioteca dados-abertos-setor-eletrico."""
+
+
+class DadosAbertosSetorEletricoHTTPError(DadosAbertosSetorEletricoError):
+    """Erro em comunicação HTTP com uma API CKAN."""
+
+
+class DadosAbertosSetorEletricoResponseError(DadosAbertosSetorEletricoError):
+    """Erro de estrutura ou conteúdo de resposta CKAN."""
 
 
 class dadosAbertosSetorEletrico:
+    """Cliente para consultar CCEE, ONS ou ANEEL via API CKAN.
 
-    def __init__(self, instituicao: str):
-        """
-        Inicializa a classe com a instituição desejada: CCEE, ONS ou ANEEL.
-        Define a URL base (host) de onde os dados serão buscados.
-        """
-        self.api = '/api/3/action/'  # Caminho comum da API CKAN usada por todas as instituições
+    Parameters
+    ----------
+    instituicao:
+        Nome da instituição: ``ccee``, ``ons`` ou ``aneel``. A comparação não
+        diferencia maiúsculas de minúsculas.
+    timeout:
+        Tempo máximo, em segundos, para cada requisição HTTP.
+    headers:
+        Cabeçalhos HTTP adicionais. Quando ``User-Agent`` não for informado,
+        a biblioteca envia um valor padrão identificável.
+    """
 
-        # Define a URL base dependendo da instituição informada
-        if str.lower(instituicao) == "ccee":
-            self.host = 'https://dadosabertos.ccee.org.br'
-        elif str.lower(instituicao) == "ons":
-            self.host = 'https://dados.ons.org.br'
-        elif str.lower(instituicao) == "aneel":
-            self.host = 'https://dadosabertos.aneel.gov.br/'
-        else:
-            raise ValueError("Instituição não encontrada!")  # Gera erro se a instituição for inválida
+    _HOSTS = {
+        "ccee": "https://dadosabertos.ccee.org.br",
+        "ons": "https://dados.ons.org.br",
+        "aneel": "https://dadosabertos.aneel.gov.br",
+    }
 
-    def listar_produtos_disponiveis(self):
-        """
-        Retorna uma lista com todos os produtos disponíveis na API.
-        Cada produto representa um conjunto de dados públicos que pode ser consultado.
-        """
-        r = requests.get(self.host + self.api + "package_list")
-        return r.json()
+    def __init__(
+        self,
+        instituicao: str,
+        timeout: float = 30.0,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.instituicao = str(instituicao).lower()
+        if self.instituicao not in self._HOSTS:
+            validas = ", ".join(sorted(self._HOSTS))
+            raise ValueError(f"Instituição não encontrada: {instituicao!r}. Use uma de: {validas}.")
 
-    def __buscar_resource_ids_por_produto(self, produto: str):
-        """
-        Retorna os IDs dos arquivos (resources) relacionados a um produto.
-        Cada resource_id representa uma tabela acessível via API.
-        """
-        r = requests.get(self.host + self.api + f"package_show?id={produto}")
-        return [item['id'] for item in r.json()['result']['resources'] if 'id' in item]
+        self.host = self._HOSTS[self.instituicao]
+        self.api = "/api/3/action/"
+        self.timeout = timeout
+        self.headers = {"User-Agent": f"dados-abertos-setor-eletrico/{__version__}"}
+        if headers:
+            self.headers.update(headers)
 
-    async def __fetch_offset(self, client, resource_id, offset, limit):
-        """
-        Função assíncrona que busca um pedaço (pagina) dos dados de um resource_id específico.
-        Trabalha com paginação (offset) e número máximo de registros (limit).
-        """
-        url = f"{self.host}{self.api}datastore_search?resource_id={resource_id}&limit={limit}&offset={offset}"
+    def _build_url(self, endpoint: str) -> str:
+        """Monta uma URL CKAN sem barras duplicadas entre host, API e endpoint."""
+        return f"{self.host.rstrip('/')}/{self.api.strip('/')}/{endpoint.lstrip('/')}"
+
+    def _format_error(self, endpoint: str, original: BaseException, status_code: Optional[int] = None) -> str:
+        status = f" Status HTTP: {status_code}." if status_code is not None else ""
+        return (
+            f"Erro ao consultar {self.instituicao.upper()} no endpoint {endpoint!r}."
+            f"{status} Erro original: {original}"
+        )
+
+    def _get_json(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Executa GET síncrono e retorna JSON validado no nível HTTP."""
+        url = self._build_url(endpoint)
         try:
-            resp = await client.get(url, timeout=30)  # Realiza a requisição de forma assíncrona
-            data = resp.json()
-            return data.get("result", {}).get("records", [])  # Retorna apenas os dados (registros)
-        except Exception as e:
-            print(f"[{resource_id}] Offset {offset} falhou: {e}")
-            return []  # Retorna lista vazia em caso de erro
+            response = requests.get(url, params=params, timeout=self.timeout, headers=self.headers)
+            response.raise_for_status()
+            data = response.json()
+        except requests.Timeout as exc:
+            raise DadosAbertosSetorEletricoHTTPError(self._format_error(endpoint, exc)) from exc
+        except requests.ConnectionError as exc:
+            raise DadosAbertosSetorEletricoHTTPError(self._format_error(endpoint, exc)) from exc
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else response.status_code
+            raise DadosAbertosSetorEletricoHTTPError(
+                self._format_error(endpoint, exc, status_code)
+            ) from exc
+        except ValueError as exc:
+            raise DadosAbertosSetorEletricoResponseError(
+                self._format_error(endpoint, exc)
+            ) from exc
 
-    async def __baixar_resource_completo(self, client, resource_id, limit=10000):
-        """
-        Função assíncrona que baixa todos os dados de um único resource_id, lidando com paginação.
-        """
+        if not isinstance(data, dict):
+            raise DadosAbertosSetorEletricoResponseError(
+                f"Resposta inválida de {self.instituicao.upper()} no endpoint {endpoint!r}: JSON não é objeto."
+            )
+        return data
+
+    def _validate_success(self, data: Dict[str, Any], endpoint: str) -> Any:
+        if data.get("success") is False:
+            raise DadosAbertosSetorEletricoResponseError(
+                f"API CKAN retornou success=false para {self.instituicao.upper()} no endpoint {endpoint!r}: "
+                f"{data.get('error')}"
+            )
+        if data.get("success") is not True or "result" not in data:
+            raise DadosAbertosSetorEletricoResponseError(
+                f"Resposta CKAN inválida de {self.instituicao.upper()} no endpoint {endpoint!r}: "
+                "esperado success=true e campo result."
+            )
+        return data["result"]
+
+    def listar_produtos_disponiveis(self) -> Dict[str, Any]:
+        """Lista produtos disponíveis e retorna a resposta CKAN completa."""
+        endpoint = "package_list"
+        data = self._get_json(endpoint)
+        result = self._validate_success(data, endpoint)
+        if not isinstance(result, list):
+            raise DadosAbertosSetorEletricoResponseError(
+                f"Resposta CKAN inválida de {self.instituicao.upper()} no endpoint {endpoint!r}: result deve ser lista."
+            )
+        return data
+
+    def __buscar_resource_ids_por_produto(self, produto: str) -> List[str]:
+        """Retorna os IDs dos resources de um produto CKAN."""
+        endpoint = "package_show"
+        data = self._get_json(endpoint, params={"id": produto})
+        result = self._validate_success(data, endpoint)
+        resources = result.get("resources") if isinstance(result, dict) else None
+        if resources is None:
+            raise DadosAbertosSetorEletricoResponseError(
+                f"Resposta CKAN inválida de {self.instituicao.upper()} no endpoint {endpoint!r}: resources ausente."
+            )
+        if not isinstance(resources, list):
+            raise DadosAbertosSetorEletricoResponseError(
+                f"Resposta CKAN inválida de {self.instituicao.upper()} no endpoint {endpoint!r}: resources deve ser lista."
+            )
+        return [item["id"] for item in resources if isinstance(item, dict) and item.get("id")]
+
+    async def __fetch_offset(self, client: httpx.AsyncClient, resource_id: str, offset: int, limit: int) -> Tuple[List[Dict[str, Any]], Optional[int]]:
+        endpoint = "datastore_search"
+        try:
+            response = await client.get(
+                self._build_url(endpoint),
+                params={"resource_id": resource_id, "limit": limit, "offset": offset},
+            )
+            response.raise_for_status()
+            data = response.json()
+        except httpx.TimeoutException as exc:
+            raise DadosAbertosSetorEletricoHTTPError(self._format_error(endpoint, exc)) from exc
+        except httpx.HTTPStatusError as exc:
+            raise DadosAbertosSetorEletricoHTTPError(
+                self._format_error(endpoint, exc, exc.response.status_code)
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise DadosAbertosSetorEletricoHTTPError(self._format_error(endpoint, exc)) from exc
+        except ValueError as exc:
+            raise DadosAbertosSetorEletricoResponseError(self._format_error(endpoint, exc)) from exc
+
+        result = self._validate_success(data, endpoint)
+        records = result.get("records") if isinstance(result, dict) else None
+        if records is None or not isinstance(records, list):
+            raise DadosAbertosSetorEletricoResponseError(
+                f"Resposta CKAN inválida de {self.instituicao.upper()} no endpoint {endpoint!r}: records ausente ou inválido."
+            )
+        total = result.get("total")
+        return records, total if isinstance(total, int) else None
+
+    async def __baixar_resource_completo(self, client: httpx.AsyncClient, resource_id: str, limit: int = 10000) -> List[Dict[str, Any]]:
         offset = 0
-        todos_registros = []
-
-        # Laço que busca página por página (de 10 mil em 10 mil)
+        todos_registros: List[Dict[str, Any]] = []
         while True:
-            registros = await self.__fetch_offset(client, resource_id, offset, limit)
+            registros, total = await self.__fetch_offset(client, resource_id, offset, limit)
             if not registros:
-                break  # Para quando não houver mais dados
-            todos_registros.extend(registros)  # Junta os dados
-            offset += limit  # Vai para a próxima página
-
+                break
+            todos_registros.extend(registros)
+            offset += limit
+            if total is not None and offset >= total:
+                break
         return todos_registros
 
-    async def baixar_dados_produto_completo_async(self, produto: str):
+    async def baixar_dados_produto_completo_async(self, produto: str) -> pd.DataFrame:
+        """Baixa todos os resources de um produto e retorna sempre um DataFrame.
+
+        Se apenas alguns resources falharem, os dados válidos são retornados e
+        um ``warnings.warn`` informa os resources com falha. Se todos falharem,
+        uma exceção agregada é lançada. Produtos sem registros retornam
+        ``pandas.DataFrame()``.
         """
-        Função principal assíncrona para baixar todos os dados de um produto.
-        Acessa vários resource_ids em paralelo e junta os dados num único DataFrame (tabela).
-        """
-        print("Iniciando download assíncrono...")
-        ids = self.__buscar_resource_ids_por_produto(produto)  # Busca os IDs dos arquivos (resources)
+        ids = self.__buscar_resource_ids_por_produto(produto)
+        if not ids:
+            return pd.DataFrame()
 
-        # Cria um cliente HTTP assíncrono
-        async with httpx.AsyncClient() as client:
-            # Cria uma lista de tarefas assíncronas, uma para cada resource_id
-            tarefas = [self.__baixar_resource_completo(client, rid) for rid in ids]
-            # Executa todas as tarefas ao mesmo tempo
-            resultados = await asyncio.gather(*tarefas)
+        async with httpx.AsyncClient(timeout=self.timeout, headers=self.headers) as client:
+            resultados = await asyncio.gather(
+                *(self.__baixar_resource_completo(client, rid) for rid in ids),
+                return_exceptions=True,
+            )
 
-        # Junta todos os registros em uma única lista
-        todos_registros = [item for sublist in resultados for item in sublist]
+        todos_registros: List[Dict[str, Any]] = []
+        falhas = []
+        for resource_id, resultado in zip(ids, resultados):
+            if isinstance(resultado, Exception):
+                falhas.append(f"{resource_id}: {resultado}")
+            else:
+                todos_registros.extend(resultado)
 
-        # Retorna um DataFrame com os dados (ou None se não houver nada)
-        return pd.DataFrame(todos_registros) if todos_registros else None
+        if falhas and len(falhas) == len(ids):
+            raise DadosAbertosSetorEletricoError(
+                f"Nenhum resource de {produto!r} foi baixado com sucesso. Falhas: " + "; ".join(falhas)
+            )
+        if falhas:
+            warnings.warn(
+                f"Alguns resources de {produto!r} falharam e foram ignorados: " + "; ".join(falhas),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        return pd.DataFrame(todos_registros)
 
-    def baixar_dados_produto_completo(self, produto: str):
-        """
-        Versão compatível com ambientes normais (como scripts Python).
-        Detecta se já existe um loop assíncrono rodando (como no Jupyter) e se adapta.
+    def baixar_dados_produto_completo(self, produto: str) -> pd.DataFrame:
+        """Versão síncrona do download completo.
+
+        Em ambientes com event loop ativo (por exemplo, Jupyter), este método
+        levanta ``RuntimeError`` para evitar retornar ``asyncio.Task``. Use
+        ``await cliente.baixar_dados_produto_completo_async(produto)`` nesses
+        casos.
         """
         try:
-            # Se já existe um loop (ex: Jupyter), cria uma tarefa
-            loop = asyncio.get_running_loop()
-            return loop.create_task(self.baixar_dados_produto_completo_async(produto))
+            asyncio.get_running_loop()
         except RuntimeError:
-            # Caso contrário, executa o método assíncrono do zero
             return asyncio.run(self.baixar_dados_produto_completo_async(produto))
+        raise RuntimeError(
+            "Há um event loop ativo. Use: await cliente.baixar_dados_produto_completo_async(produto)."
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: testes opcionais que fazem chamadas reais às APIs CKAN",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dados-abertos-setor-eletrico
-version = 0.1.4
+version = 0.1.5
 author = Diego Neri
 author_email = diego.holanda.neri@gmail.com
 description = Coleta e tratamento de dados públicos do setor elétrico brasileiro (ONS, CCEE e ANEEL).

--- a/tests/test_dadosAbertosSetorEletrico.py
+++ b/tests/test_dadosAbertosSetorEletrico.py
@@ -1,128 +1,239 @@
-import pytest
-from unittest.mock import patch, AsyncMock
-from dadosAbertosSetorEletrico import dadosAbertosSetorEletrico
+import asyncio
+import os
+from unittest.mock import Mock, patch
+
+import httpx
 import pandas as pd
+import pytest
+import requests
 
-# -------------------
-# Testes de inicialização da classe
-# -------------------
+from dadosAbertosSetorEletrico import (
+    DadosAbertosSetorEletricoError,
+    DadosAbertosSetorEletricoHTTPError,
+    DadosAbertosSetorEletricoResponseError,
+    dadosAbertosSetorEletrico,
+)
 
-def test_init_ccee():
-    # Testa se, ao inicializar com "ccee", o host é atribuido corretamente
-    cliente = dadosAbertosSetorEletrico("ccee")
-    assert cliente.host == "https://dadosabertos.ccee.org.br"
+
+def make_response(payload=None, status_code=200, json_error=None):
+    response = Mock()
+    response.status_code = status_code
+    response.json.side_effect = json_error if json_error else None
+    response.json.return_value = payload
+    if status_code >= 400:
+        http_error = requests.HTTPError(f"{status_code} error")
+        http_error.response = response
+        response.raise_for_status.side_effect = http_error
+    else:
+        response.raise_for_status.return_value = None
+    return response
+
+
+def test_init_instituicoes_e_case_insensitive():
+    assert dadosAbertosSetorEletrico("ccee").host == "https://dadosabertos.ccee.org.br"
+    assert dadosAbertosSetorEletrico("ONS").host == "https://dados.ons.org.br"
+    assert dadosAbertosSetorEletrico("AnEeL").host == "https://dadosabertos.aneel.gov.br"
+
 
 def test_init_invalido():
-    # Testa se, ao passar uma instituição inválida, uma exceção é levantada
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Instituição não encontrada"):
         dadosAbertosSetorEletrico("xyz")
 
-# -------------------
-# Teste de listagem de produtos com simulação da API
-# -------------------
+
+def test_construcao_correta_urls():
+    assert dadosAbertosSetorEletrico("ccee")._build_url("package_list") == "https://dadosabertos.ccee.org.br/api/3/action/package_list"
+    assert dadosAbertosSetorEletrico("ons")._build_url("/package_list") == "https://dados.ons.org.br/api/3/action/package_list"
+    assert dadosAbertosSetorEletrico("aneel")._build_url("package_list") == "https://dadosabertos.aneel.gov.br/api/3/action/package_list"
+
+
 @patch("dadosAbertosSetorEletrico.requests.get")
-def test_listar_produtos_disponiveis(mock_get):
-    # Simula resposta da API com dois produtos
-    mock_get.return_value.json.return_value = {"result": ["produto1", "produto2"]}
+def test_package_list_com_sucesso(mock_get):
+    mock_get.return_value = make_response({"success": True, "result": ["produto1", "produto2"]})
     cliente = dadosAbertosSetorEletrico("ccee")
-    produtos = cliente.listar_produtos_disponiveis()
-    assert produtos["result"] == ["produto1", "produto2"]
+    resposta = cliente.listar_produtos_disponiveis()
+    assert resposta["result"] == ["produto1", "produto2"]
+    mock_get.assert_called_once_with(
+        "https://dadosabertos.ccee.org.br/api/3/action/package_list",
+        params=None,
+        timeout=30.0,
+        headers=cliente.headers,
+    )
 
-# -------------------
-# Teste de busca de resource_ids simulando resposta da API
-# -------------------
+
+@pytest.mark.parametrize("status", [404, 429])
 @patch("dadosAbertosSetorEletrico.requests.get")
-def test_buscar_resource_ids(mock_get):
-    # Simula resposta com dois IDs de recurso
-    mock_get.return_value.json.return_value = {
-        "result": {"resources": [{"id": "abc"}, {"id": "def"}]}
-    }
+def test_erro_http(mock_get, status):
+    mock_get.return_value = make_response(status_code=status)
+    with pytest.raises(DadosAbertosSetorEletricoHTTPError, match=f"Status HTTP: {status}"):
+        dadosAbertosSetorEletrico("ccee").listar_produtos_disponiveis()
+
+
+@patch("dadosAbertosSetorEletrico.requests.get")
+def test_timeout(mock_get):
+    mock_get.side_effect = requests.Timeout("tempo esgotado")
+    with pytest.raises(DadosAbertosSetorEletricoHTTPError, match="tempo esgotado"):
+        dadosAbertosSetorEletrico("ons").listar_produtos_disponiveis()
+
+
+@patch("dadosAbertosSetorEletrico.requests.get")
+def test_conexao_recusada(mock_get):
+    mock_get.side_effect = requests.ConnectionError("conexão recusada")
+    with pytest.raises(DadosAbertosSetorEletricoHTTPError, match="conexão recusada"):
+        dadosAbertosSetorEletrico("aneel").listar_produtos_disponiveis()
+
+
+@patch("dadosAbertosSetorEletrico.requests.get")
+def test_json_invalido(mock_get):
+    mock_get.return_value = make_response(json_error=ValueError("json inválido"))
+    with pytest.raises(DadosAbertosSetorEletricoResponseError, match="json inválido"):
+        dadosAbertosSetorEletrico("ccee").listar_produtos_disponiveis()
+
+
+@patch("dadosAbertosSetorEletrico.requests.get")
+def test_ckan_success_false(mock_get):
+    mock_get.return_value = make_response({"success": False, "error": {"message": "falha"}})
+    with pytest.raises(DadosAbertosSetorEletricoResponseError, match="success=false"):
+        dadosAbertosSetorEletrico("ccee").listar_produtos_disponiveis()
+
+
+@patch("dadosAbertosSetorEletrico.requests.get")
+def test_package_show_sem_resources(mock_get):
+    mock_get.return_value = make_response({"success": True, "result": {}})
     cliente = dadosAbertosSetorEletrico("ccee")
-    ids = cliente._dadosAbertosSetorEletrico__buscar_resource_ids_por_produto("algum-produto")
-    assert ids == ["abc", "def"]
+    with pytest.raises(DadosAbertosSetorEletricoResponseError, match="resources ausente"):
+        cliente._dadosAbertosSetorEletrico__buscar_resource_ids_por_produto("produto")
 
-# -------------------
-# Teste assíncrono com multiplos resource_ids e paginação
-# -------------------
-@pytest.mark.asyncio
-async def test_baixar_dados_mockado():
+
+@patch("dadosAbertosSetorEletrico.requests.get")
+def test_multiplos_resources(mock_get):
+    mock_get.return_value = make_response({"success": True, "result": {"resources": [{"id": "r1"}, {"id": "r2"}]}})
     cliente = dadosAbertosSetorEletrico("ccee")
+    assert cliente._dadosAbertosSetorEletrico__buscar_resource_ids_por_produto("produto") == ["r1", "r2"]
 
-    chamadas = []
 
-    # Simula comportamento paginado: retorna dado no offset 0 e vazio depois
-    async def fake_fetch_offset(client, resource_id, offset, limit):
-        chamadas.append((resource_id, offset))
-        if offset == 0:
-            return [{"coluna": f"valor_{resource_id}"}]
-        else:
+def test_paginacao_mais_de_uma_pagina():
+    async def run():
+        cliente = dadosAbertosSetorEletrico("ccee")
+        chamadas = []
+
+        async def fake_fetch(client, resource_id, offset, limit):
+            chamadas.append(offset)
+            if offset == 0:
+                return [{"a": 1}], 2
+            if offset == 1:
+                return [{"a": 2}], 2
+            return [], 2
+
+        cliente._dadosAbertosSetorEletrico__fetch_offset = fake_fetch
+        dados = await cliente._dadosAbertosSetorEletrico__baixar_resource_completo(Mock(), "r1", limit=1)
+        assert dados == [{"a": 1}, {"a": 2}]
+        assert chamadas == [0, 1]
+
+    asyncio.run(run())
+
+
+def test_recurso_vazio_retorna_dataframe_vazio():
+    async def run():
+        cliente = dadosAbertosSetorEletrico("ccee")
+        cliente._dadosAbertosSetorEletrico__buscar_resource_ids_por_produto = lambda produto: ["vazio"]
+
+        async def fake_resource(client, resource_id):
             return []
 
-    # Substitui os métodos internos por versões simuladas (mocks)
-    cliente._dadosAbertosSetorEletrico__buscar_resource_ids_por_produto = lambda x: ["id1", "id2"]
-    cliente._dadosAbertosSetorEletrico__fetch_offset = fake_fetch_offset
+        cliente._dadosAbertosSetorEletrico__baixar_resource_completo = fake_resource
+        df = await cliente.baixar_dados_produto_completo_async("produto")
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
 
-    # Executa a função com os mocks
-    df = await cliente.baixar_dados_produto_completo_async("produto-teste")
+    asyncio.run(run())
 
-    # Verifica se os dados retornados estão corretos
-    assert not df.empty
-    assert set(df["coluna"]) == {"valor_id1", "valor_id2"}
-    assert chamadas == [("id1", 0), ("id1", 10000), ("id2", 0), ("id2", 10000)]
 
-# -------------------
-# Teste com um resource_id que falha
-# -------------------
-@pytest.mark.asyncio
-async def test_baixar_dados_com_erro():
-    cliente = dadosAbertosSetorEletrico("ccee")
+def test_falha_em_apenas_um_recurso_emite_warning():
+    async def run():
+        cliente = dadosAbertosSetorEletrico("ccee")
+        cliente._dadosAbertosSetorEletrico__buscar_resource_ids_por_produto = lambda produto: ["ok", "erro"]
 
-    # Simula uma exceção para um dos resource_ids
-    async def fake_fetch_offset(client, resource_id, offset, limit):
-        if resource_id == "erro":
-            raise Exception("Erro simulado")
-        if offset == 0:
+        async def fake_resource(client, resource_id):
+            if resource_id == "erro":
+                raise DadosAbertosSetorEletricoHTTPError("falha")
             return [{"coluna": "ok"}]
-        return []
 
-    # Define que haverá um resource_id válido e um que falha
-    cliente._dadosAbertosSetorEletrico__buscar_resource_ids_por_produto = lambda x: ["ok", "erro"]
+        cliente._dadosAbertosSetorEletrico__baixar_resource_completo = fake_resource
+        with pytest.warns(RuntimeWarning, match="erro"):
+            df = await cliente.baixar_dados_produto_completo_async("produto")
+        assert df["coluna"].tolist() == ["ok"]
 
-    # Envolve o fake_fetch em tratamento de erro para evitar crash do teste
-    async def safe_fetch(client, resource_id, offset, limit):
-        try:
-            return await fake_fetch_offset(client, resource_id, offset, limit)
-        except:
-            return []
+    asyncio.run(run())
 
-    cliente._dadosAbertosSetorEletrico__fetch_offset = safe_fetch
 
-    df = await cliente.baixar_dados_produto_completo_async("produto-teste")
+def test_falha_em_todos_os_recursos():
+    async def run():
+        cliente = dadosAbertosSetorEletrico("ccee")
+        cliente._dadosAbertosSetorEletrico__buscar_resource_ids_por_produto = lambda produto: ["r1", "r2"]
 
-    # Garante que pelo menos o resource_id válido foi retornado
-    assert isinstance(df, pd.DataFrame)
-    assert not df.empty
-    assert "coluna" in df.columns
-    assert "ok" in df["coluna"].values or len(df) == 1
+        async def fake_resource(client, resource_id):
+            raise DadosAbertosSetorEletricoHTTPError("falha")
 
-# -------------------
-# Teste de um resource_id que não retorna nenhum dado
-# -------------------
-@pytest.mark.asyncio
-async def test_baixar_dados_vazio():
+        cliente._dadosAbertosSetorEletrico__baixar_resource_completo = fake_resource
+        with pytest.raises(DadosAbertosSetorEletricoError, match="Nenhum resource"):
+            await cliente.baixar_dados_produto_completo_async("produto")
+
+    asyncio.run(run())
+
+
+def test_metodo_sincrono_fora_de_event_loop():
     cliente = dadosAbertosSetorEletrico("ccee")
 
-    # Simula resposta vazia para todos os offsets
-    async def fake_fetch_offset(client, resource_id, offset, limit):
-        return []
+    async def fake_async(produto):
+        return pd.DataFrame([{"produto": produto}])
 
-    cliente._dadosAbertosSetorEletrico__buscar_resource_ids_por_produto = lambda x: ["id_vazio"]
-    cliente._dadosAbertosSetorEletrico__fetch_offset = fake_fetch_offset
-
-    df = await cliente.baixar_dados_produto_completo_async("produto-teste")
-    if df is None:
-        df = pd.DataFrame()  # Garante consistência no retorno para facilitar validação
-
-    # Verifica se é um DataFrame válido e vazio
+    cliente.baixar_dados_produto_completo_async = fake_async
+    df = cliente.baixar_dados_produto_completo("abc")
     assert isinstance(df, pd.DataFrame)
-    assert df.empty
+    assert df.iloc[0]["produto"] == "abc"
+
+
+def test_metodo_sincrono_dentro_de_event_loop():
+    async def run():
+        cliente = dadosAbertosSetorEletrico("ccee")
+        with pytest.raises(RuntimeError, match="event loop ativo"):
+            cliente.baixar_dados_produto_completo("abc")
+
+    asyncio.run(run())
+
+
+def test_headers_customizados_e_user_agent_padrao():
+    cliente = dadosAbertosSetorEletrico("ccee", headers={"X-Teste": "1"})
+    assert cliente.headers["User-Agent"] == "dados-abertos-setor-eletrico/0.1.5"
+    assert cliente.headers["X-Teste"] == "1"
+
+
+def test_user_agent_customizado():
+    cliente = dadosAbertosSetorEletrico("ccee", headers={"User-Agent": "custom"})
+    assert cliente.headers["User-Agent"] == "custom"
+
+
+def test_datastore_success_false():
+    async def run():
+        request = httpx.Request("GET", "https://example.test")
+        response = httpx.Response(200, json={"success": False, "error": {"message": "falha"}}, request=request)
+
+        class Transport(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request):
+                return response
+
+        cliente = dadosAbertosSetorEletrico("ccee")
+        async with httpx.AsyncClient(transport=Transport()) as client:
+            with pytest.raises(DadosAbertosSetorEletricoResponseError, match="success=false"):
+                await cliente._dadosAbertosSetorEletrico__fetch_offset(client, "r1", 0, 100)
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(os.getenv("RUN_INTEGRATION_TESTS") != "1", reason="defina RUN_INTEGRATION_TESTS=1")
+@pytest.mark.parametrize("instituicao", ["ccee", "ons", "aneel"])
+def test_integration_package_list(instituicao):
+    resposta = dadosAbertosSetorEletrico(instituicao, timeout=10).listar_produtos_disponiveis()
+    assert resposta["success"] is True
+    assert isinstance(resposta["result"], list)


### PR DESCRIPTION
### Motivation

- Corrigir construção de URLs CKAN para evitar barras duplas e garantir endpoints previsíveis para CCEE, ONS e ANEEL.  
- Tornar as requisições HTTP mais seguras e informativas (timeout, `raise_for_status`, tratamento de erros e `User-Agent`).  
- Garantir comportamento previsível de download (retorno sempre `pandas.DataFrame` quando bem sucedido) e melhorar cobertura de testes unitários/mocked.

### Description

- Atualizei a versão para `0.1.5` em `dadosAbertosSetorEletrico/__init__.py` e `setup.cfg` e incluí `LICENSE.txt` no `MANIFEST.in`.  
- Padronizei hosts em `_HOSTS` sem barra final e adicionei `_build_url(endpoint)` para montar URLs no formato `https://.../api/3/action/<endpoint>` sem barras duplicadas.  
- Implementei `_get_json(...)` (síncrono) com `timeout`, `headers` (inclui `User-Agent` por padrão), `response.raise_for_status()` e tratamentos específicos para `requests.Timeout`, `requests.ConnectionError`, `requests.HTTPError` e JSON inválido, com exceções próprias (`DadosAbertosSetorEletricoError`, `DadosAbertosSetorEletricoHTTPError`, `DadosAbertosSetorEletricoResponseError`).  
- Reescrevi a lógica assíncrona para usar `httpx.AsyncClient` com timeout/headers, `raise_for_status()`, paginação controlada (usa `total` quando disponível), acumula erros por `resource_id` e retorna sempre um `pandas.DataFrame` com `warnings.warn()` em falhas parciais ou lança exceção agregada se todos falharem; o método síncrono `baixar_dados_produto_completo` agora levanta `RuntimeError` quando há event loop ativo (orienta uso de `await`).  
- Atualizei/expandi a suíte de testes mockados em `tests/test_dadosAbertosSetorEletrico.py`, adicionei marcador `integration` no `pyproject.toml` (testes reais opcionais desabilitados por padrão) e atualizei o `README.md` com exemplos, erros e instruções de publicação.

### Testing

- Rodei `pytest -v` no repositório modificado: `21 passed, 3 skipped` (os 3 são testes de integração opcionais marcados com `@pytest.mark.integration`).  
- Antes das correções a execução inicial mostrou problemas (ex.: async marcado sem plugin) — após ajustes nos testes e implementação os unit tests mockados passaram.  
- Tentativas de validar `python -m build` e `python -m twine check dist/*` falharam neste ambiente por falta de `setuptools`/`wheel`/`build`/`twine` e por bloqueio de proxy (403), portanto a build/twine check devem ser executadas em um ambiente com acesso a PyPI/build tools; comandos recomendados: `python -m build` e `python -m twine check dist/*`.  
- Como validação alternativa, montei um wheel manual e instalei em um `venv` temporário e verifiquei importação do pacote, construção de clientes (`ccee`,`ons`,`aneel`) e uma chamada `package_list` mockada com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62bd51f58c8333bb1740b46a23bff0)